### PR TITLE
Fix error messages to use resolve instead of join

### DIFF
--- a/lib/src-resolver.js
+++ b/lib/src-resolver.js
@@ -62,9 +62,9 @@ function SrcResolver(config) {
       err.file = module.lastRequiredBy ? module.lastRequiredBy.fullPath : '@'; // firebug convention
       err.longDesc = err.toString() + '\n    in ' + err.file + '\nTried looking for it in the following files:';
       self.paths.forEach(function(searchPath) {
-        err.longDesc +='\n    ' + path.join(self.root, searchPath, relativePath + exts);
+        err.longDesc +='\n    ' + path.resolve(self.root, searchPath, relativePath + exts);
         if (self.allowDirModules) {
-          err.longDesc +='\n    ' + path.join(self.root, searchPath, relativePath, 'index' + exts);
+          err.longDesc +='\n    ' + path.resolve(self.root, searchPath, relativePath, 'index' + exts);
         }
       });
       err.toString = function() { return err.longDesc };


### PR DESCRIPTION
When looking for the paths to build the dependency graph, the code uses `path.resolve`, but the error messages are using `path.join`. This yields incorrect error messages when `searchPath` is an absolute path.
