### PR TITLE
Add support for node modules

### DIFF
--- a/lib/src-resolver.js
+++ b/lib/src-resolver.js
@@ -88,7 +88,8 @@ function SrcResolver(config) {
   p.resolveExtension = resolveExtension;
   function resolveExtension(fullPath, module, callback) {
     var self = this;
-    serialize.forEach(this.config.extensions, function(ext, checkNextExtension) {
+    var extensionsToCheck = this.config.extensions.concat('');
+    serialize.forEach(extensionsToCheck, function(ext, checkNextExtension) {
       var p = fullPath + ext;
       fs.stat(p, function(err, stats) {
         if (!err && stats.isFile()) {


### PR DESCRIPTION
In node, main is a JS file rather than a module. This adds support for that. See #10
